### PR TITLE
fix(github-actions): trigger ci only on pull request activities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Avoid double running ci in pull requests