### PR TITLE
fix(vcpkg): use correct json schema url

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "@cpp_pt_name@",
   "version-string": "0.0.1",
   "dependencies": [


### PR DESCRIPTION
The canonical JSON schema URL for `vcpkg.json` has changed. Update it.

Source: https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json